### PR TITLE
maintainer-label

### DIFF
--- a/10-alpine/Dockerfile
+++ b/10-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:10-alpine
 
-LABEL Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/12-alpine/Dockerfile
+++ b/12-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-alpine
 
-LABEL Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/14-apline/Dockerfile
+++ b/14-apline/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14-alpine as base
 
-LABEL Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/4-alpine/Dockerfile
+++ b/4-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:4-alpine
 
-LABEL Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/6-alpine/Dockerfile
+++ b/6-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:6-alpine
 
-LABEL Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/7-alpine/Dockerfile
+++ b/7-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:7-alpine
 
-LABEL Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/8-alpine/Dockerfile
+++ b/8-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:8-alpine
 
-LABEL Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM node:%VERSION%
 
-MAINTAINER Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \


### PR DESCRIPTION
Updating implementation for LABEL based in https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

